### PR TITLE
Added support for .netstandard 2.0

### DIFF
--- a/DSTV.Net.Test/DSTV.Net.Test.csproj
+++ b/DSTV.Net.Test/DSTV.Net.Test.csproj
@@ -3,6 +3,7 @@
     <PropertyGroup>
         <IsPackable>false</IsPackable>
         <Title>Testclass for DSTV.Net</Title>
+		<TargetFrameworks>net6.0;net7.0;</TargetFrameworks>
     </PropertyGroup>
 
     <ItemGroup>

--- a/DSTV.Net/DSTV.Net.csproj
+++ b/DSTV.Net/DSTV.Net.csproj
@@ -3,6 +3,7 @@
     <PropertyGroup>
         <Description>DSTV.Net is an open-source library tailored for .NET platforms, providing a powerful utility for interacting with DSTV (also known as NC1 or Tekla) files. These files serve as a key industry standard in the steel industry, defining geometry and project information for steel plates.</Description>
         <PackageProjectUrl>https://github.com/Baseflow/DSTV.Net</PackageProjectUrl>
+        <TargetFrameworks>net6.0;net7.0;netstandard2.0</TargetFrameworks>
     </PropertyGroup>
 
     <ItemGroup>

--- a/DSTV.Net/Data/DstvElement.cs
+++ b/DSTV.Net/Data/DstvElement.cs
@@ -27,7 +27,7 @@ public record DstvElement
         if (separated is null) throw new ArgumentNullException(nameof(separated));
         for (var i = skipFirst ? 1 : 0; i < separated.Length - (skipLast ? 1 : 0); i++)
         {
-            foreach (var match in Regex.Matches(separated[i], "([^.\\d-]+)", RegexOptions.ExplicitCapture, TimeSpan.FromSeconds(1)).AsEnumerable())
+            foreach (Match match in Regex.Matches(separated[i], "([^.\\d-]+)", RegexOptions.ExplicitCapture, TimeSpan.FromSeconds(1)))
                 separated[i] = separated[i].Replace(match.Value, string.Empty, StringComparison.Ordinal);
         }
 

--- a/DSTV.Net/Implementations/BodyReader.cs
+++ b/DSTV.Net/Implementations/BodyReader.cs
@@ -118,7 +118,7 @@ internal static class BodyReader
 
             if (CheckCodeLine(line))
             {
-                curKey = Enum.Parse<ContourType>(line);
+                curKey = (ContourType)Enum.Parse(typeof(ContourType), line);
                 if (!CheckIfMark(line)) Console.WriteLine(line + "Warning: unregistered DStV code-line detected: ");
 
                 if (!elemMap.ContainsKey(curKey)) elemMap.Add(curKey, new List<List<string>>());

--- a/DSTV.Net/Implementations/FineSplitter.cs
+++ b/DSTV.Net/Implementations/FineSplitter.cs
@@ -9,5 +9,5 @@ internal class FineSplitter : ISplitter
     /// <summary>
     ///     Splitter for full carefully splitting - saving all lexemes
     /// </summary>
-    public string[] Split(string input) => input.Split(" ", StringSplitOptions.RemoveEmptyEntries);
+    public string[] Split(string input) => input.Split(new [] {" "}, StringSplitOptions.RemoveEmptyEntries);
 }

--- a/DSTV.Net/Implementations/RoughSplitter.cs
+++ b/DSTV.Net/Implementations/RoughSplitter.cs
@@ -12,7 +12,7 @@ internal class RoughSplitter : ISplitter
     /// </summary>
     public string[] Split(string input)
     {
-        var match = Regex.Match(input, "(?<!\\s|\\D)[a-z]+(?!\\s+|\\D)|\\s+", RegexOptions.None, TimeSpan.FromSeconds(1));
-        return match.Success ? match.Value.Split(match.Value) : new[] { input };
+        var match = Regex.Match(input, @"(?<!\s|\D)[a-z]+(?!\s+|\D)|\s+", RegexOptions.None, TimeSpan.FromSeconds(1));
+        return match.Success ? match.Value.Split(new [] { match.Value }, StringSplitOptions.None) : new[] { input };
     }
 }

--- a/DSTVReader.sln.DotSettings
+++ b/DSTVReader.sln.DotSettings
@@ -1,2 +1,0 @@
-﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
-	<s:Boolean x:Key="/Default/UserDictionary/Words/=DSTV/@EntryIndexedValue">True</s:Boolean></wpf:ResourceDictionary>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -18,7 +18,6 @@
 		<Product>$(AssemblyName) ($(TargetFramework))</Product>
 		<Version>1.1.1</Version>
 
-		<TargetFrameworks>net6.0;net7.0</TargetFrameworks>
 		<Nullable>enable</Nullable>
 		<ImplicitUsings>enable</ImplicitUsings>
 		<LangVersion>latest</LangVersion>


### PR DESCRIPTION
Added support for .netstandard 2.0.

I've separated the build targets for the test project and the library project. If I were to set netstandard20 as a target framework on the directory level, the xUnit runners are restored using .NET Framework 4.7.3, which isn't available on Linux. 

Other notable changes: 
* netstandard 2.0 only supports string splits by string arrays, not a single string value.
* Parsing a Enum value can not be realised using the generic API.
* Iterating over Rexeg matches works differently in netstandard2.0.