### PR TITLE
Fix compilation errors for .NET

### DIFF
--- a/DSTV.Net/Data/Contour.cs
+++ b/DSTV.Net/Data/Contour.cs
@@ -23,7 +23,11 @@ public record Contour : DstvElement
     [SuppressMessage("Design", "MA0016:Prefer returning collection abstraction instead of implementation", Justification = "This is a record")]
     public static IEnumerable<Contour> CreateSeveralContours(List<DstvContourPoint> pointList, ContourType type)
     {
+#if NET
+        ArgumentNullException.ThrowIfNull(pointList, nameof(pointList));
+#else
         if (pointList is null) throw new ArgumentNullException(nameof(pointList));
+#endif
 
         List<Contour> outList = new();
         if (type is ContourType.AK or ContourType.IK)

--- a/DSTV.Net/Data/DstvElement.cs
+++ b/DSTV.Net/Data/DstvElement.cs
@@ -9,7 +9,11 @@ public record DstvElement
 {
     protected static string[] GetDataVector(string dstvElementLine, ISplitter splitter)
     {
+#if NET
+        ArgumentNullException.ThrowIfNull(splitter, nameof(splitter));
+#else
         if (splitter is null) throw new ArgumentNullException(nameof(splitter));
+#endif
         if (Regex.IsMatch(dstvElementLine, "^\\*\\*.*", RegexOptions.None, TimeSpan.FromSeconds(1)))
             throw new DstvParseException("Attempt to get data from quote-line detected");
 
@@ -24,7 +28,11 @@ public record DstvElement
 
     protected static string[] CorrectSplits(string[] separated, bool skipFirst = false, bool skipLast = false)
     {
+#if NET
+        ArgumentNullException.ThrowIfNull(separated, nameof(separated));
+#else
         if (separated is null) throw new ArgumentNullException(nameof(separated));
+#endif
         for (var i = skipFirst ? 1 : 0; i < separated.Length - (skipLast ? 1 : 0); i++)
         {
             foreach (Match match in Regex.Matches(separated[i], "([^.\\d-]+)", RegexOptions.ExplicitCapture, TimeSpan.FromSeconds(1)))

--- a/DSTV.Net/Implementations/DotSplitter.cs
+++ b/DSTV.Net/Implementations/DotSplitter.cs
@@ -16,7 +16,7 @@ internal class DotSplitter : ISplitter
         {
             var prevPos = 0;
             if (i > 0) prevPos = dotPoss[i - 1];
-            dotPoss[i] = input.IndexOf(".", prevPos + 1, StringComparison.Ordinal);
+            dotPoss[i] = input.IndexOf('.', prevPos + 1);
         }
 
         var outArr = new string[n];

--- a/DSTV.Net/Implementations/DstvReader.cs
+++ b/DSTV.Net/Implementations/DstvReader.cs
@@ -15,7 +15,11 @@ public sealed class DstvReader : IDstvReader
 
     public async Task<IDstv> ParseAsync(TextReader reader)
     {
+#if NET
+        ArgumentNullException.ThrowIfNull(reader, nameof(reader));
+#else
         if (reader == null) throw new ArgumentNullException(nameof(reader));
+#endif
 
         var context = new ReaderContext(reader);
 

--- a/DSTV.Net/Implementations/FineSplitter.cs
+++ b/DSTV.Net/Implementations/FineSplitter.cs
@@ -9,5 +9,8 @@ internal class FineSplitter : ISplitter
     /// <summary>
     ///     Splitter for full carefully splitting - saving all lexemes
     /// </summary>
-    public string[] Split(string input) => input.Split(new [] {" "}, StringSplitOptions.RemoveEmptyEntries);
+    public string[] Split(string input) => input.Split(SplitSeparators, StringSplitOptions.RemoveEmptyEntries);
+
+    private static readonly char[] SplitSeparators = new char[] { ' ' };
+
 }


### PR DESCRIPTION
- Replaced string-based IndexOf with char-based IndexOf for single character search.
- Used static readonly field for split separators to comply with CA1861 recommendation.
- Improved performance by avoiding unnecessary instantiation of arrays.

No functional changes, only compilation fixes and minor optimizations.